### PR TITLE
[Flutter][ExpenseTracker][Fix] Evaluate Math Expression on Add/Update expense COA button press

### DIFF
--- a/flutter/expense_tracker/.gitignore
+++ b/flutter/expense_tracker/.gitignore
@@ -39,6 +39,8 @@ app.*.symbols
 # Obfuscation related
 app.*.map.json
 
+key.properties
+
 # Android Studio will place build artifacts here
 /android/app/debug
 /android/app/profile

--- a/flutter/expense_tracker/lib/widgets/expense_form.dart
+++ b/flutter/expense_tracker/lib/widgets/expense_form.dart
@@ -77,6 +77,7 @@ class _ExpenseFormState extends ConsumerState<ExpenseForm> {
 
   void _submit() {
     HapticFeedback.selectionClick();
+    _evaluateAmountExpression();
     final enteredAmount = double.tryParse(_amount.text);
     if (enteredAmount == null || enteredAmount == 0) {
       showDialogNotification('Invalid Amount',


### PR DESCRIPTION
## WHAT
Evaluate the expression not only on node de-focus, but also when the call-to-action button is pressed.

## WHY
There were validation errors occurring because the submit logic was running before the de-focus logic